### PR TITLE
Improve API naming, error handling, tests, and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.19.x', '1.20.x', '1.21.x' ]
+        go: [ '1.21.x', '1.22.x', '1.23.x' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -31,3 +31,10 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Test
         run: go test ./... -coverprofile=coverage.txt
+      - name: Upload coverage
+        if: matrix.go == '1.23.x'
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.txt
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-run:
-  deadline: 5m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - depguard
@@ -11,31 +9,54 @@ linters:
     - errcheck
     - exhaustive
     - funlen
-    - gas
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
-    - megacheck
     - misspell
+    - mnd
     - nakedret
-    - noctx
     - nolintlint
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  fast: false
+  settings:
+    depguard:
+      rules:
+        main:
+          allow:
+            - $gostd
+            - github.com/google/go-cmp
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+simplehttp is a Go HTTP client library that wraps `net/http` to eliminate boilerplate. It provides a single-file implementation (`simplehttp.go`) where request parameters (headers, data, query params) are set as client attributes rather than passed per-call.
+
+## Git Workflow
+
+Never commit directly to main. Always create a feature branch for changes.
+
+## Common Commands
+
+- **Run tests:** `go test -v ./...`
+- **Run a single test/subtest:** `go test -v -run TestWrapperMethods/GET ./...`
+- **Check formatting:** `gofmt -l .` (CI enforces this via `make fmt`)
+- **Lint:** `golangci-lint run -v` (config in `.golangci.yml`, ~40 linters enabled)
+- **All checks:** `make all` (runs fmt + test)
+
+## Architecture
+
+The entire library is a single package with two exported types:
+
+- **`HTTPClient`** — holds `BaseURL`, `Headers`, `Data`, `Params` (all `map[string]string`), and a `Client *http.Client` with a 10-second timeout. Created via `New(baseURL)`.
+- **`HTTPResponse`** — contains `Body` (string), `Code` (int), `Headers` (map[string][]string).
+
+All HTTP method functions (`Get`, `Post`, `Patch`, `Put`, `Delete`, `Head`) delegate to the unexported `sendRequest`, which marshals `Data` as JSON, applies headers and query params, executes the request, and reads the full response body into a string.
+
+**Design note:** `context.Context` is intentionally omitted from the API to keep it simple. This library prioritizes ease of use over composability in larger context-propagating systems.
+
+## Testing
+
+Tests use `httptest.NewTLSServer` with a custom handler (`handleHTTP`) that routes by method and path. Test fixtures live in `fixtures/`. The only external dependency is `github.com/google/go-cmp` (used for test comparisons).
+
+## CI
+
+GitHub Actions runs `go test ./... -coverprofile=coverage.txt` across Go 1.21, 1.22, and 1.23 on ubuntu-latest. Coverage is uploaded to Codecov on the latest Go version. Triggered on push/PR to main (ignoring `.md` files).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ client.Headers["Accept"] = "application/json"
 client.Params["key"] = "value"
 
 response, err := client.Get("/")
-// response is an HttpResponse object
+// response is an HTTPResponse object
 ```
 
 #### POST
@@ -50,6 +50,37 @@ client.Data["key"] = "value"
 
 response, err := client.Post("/")
 ```
+
+#### HEAD
+
+```go
+client := simplehttp.New("https://yoururl.here")
+response, err := client.Head("/")
+// response.Body will be empty; inspect response.Headers and response.Code
+```
+
+### HTTPResponse
+
+All methods return an `HTTPResponse` struct:
+
+| Field   | Type                  | Description                           |
+|---------|-----------------------|---------------------------------------|
+| Body    | `string`              | The response body                     |
+| Code    | `int`                 | The HTTP status code                  |
+| Headers | `map[string][]string` | The response headers (multi-valued)   |
+
+### Timeout
+
+The default timeout is 10 seconds. Use `SetTimeout` to change it:
+
+```go
+client := simplehttp.New("https://yoururl.here")
+client.SetTimeout(30 * time.Second)
+```
+
+### A note on `context.Context`
+
+This library intentionally omits `context.Context` from its API to keep things simple. If you need per-request cancellation or deadlines, you can access the underlying `*http.Client` via the `Client` field.
 
 ### Supported methods
 

--- a/simplehttp.go
+++ b/simplehttp.go
@@ -9,50 +9,59 @@ import (
 	"time"
 )
 
-type HttpClient struct {
-	BaseURL    string
-	Headers    map[string]string
-	Data       map[string]string
-	Params     map[string]string
-	HTTPClient *http.Client
+const defaultTimeout = 10 * time.Second
+
+type HTTPClient struct {
+	BaseURL string
+	Headers map[string]string
+	Data    map[string]string
+	Params  map[string]string
+	Client  *http.Client
 }
 
-type HttpResponse struct {
+type HTTPResponse struct {
 	Body    string
 	Code    int
 	Headers map[string][]string
 }
 
-func New(baseURL string) *HttpClient {
-	return &HttpClient{
+func New(baseURL string) *HTTPClient {
+	return &HTTPClient{
 		BaseURL: baseURL,
 		Headers: make(map[string]string),
 		Data:    make(map[string]string),
 		Params:  make(map[string]string),
-		HTTPClient: &http.Client{
-			Timeout: time.Second * 10,
+		Client: &http.Client{
+			Timeout: defaultTimeout,
 		},
 	}
 }
 
-func sendRequest(client *HttpClient, path string, method string) (HttpResponse, error) {
+func (client *HTTPClient) SetTimeout(timeout time.Duration) {
+	client.Client.Timeout = timeout
+}
+
+func sendRequest(client *HTTPClient, path string, method string) (HTTPResponse, error) {
+	if client.Client == nil {
+		return HTTPResponse{}, fmt.Errorf("simplehttp: %s %s: http client is nil", method, path)
+	}
+
 	// create the request body, as appropriate
 	var requestData []byte
 	if len(client.Data) > 0 {
 		var err error
 		requestData, err = json.Marshal(client.Data)
 		if err != nil {
-			return HttpResponse{}, err
+			return HTTPResponse{}, fmt.Errorf("simplehttp: %s %s: marshaling request data: %w", method, path, err)
 		}
 	}
 
 	// construct the request
 	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", client.BaseURL, path), bytes.NewBuffer(requestData))
 	if err != nil {
-		return HttpResponse{}, err
+		return HTTPResponse{}, fmt.Errorf("simplehttp: %s %s: creating request: %w", method, path, err)
 	}
 	for k, v := range client.Headers {
-		// req.Header.Set(k, v[0])
 		req.Header.Set(k, v)
 	}
 
@@ -64,50 +73,50 @@ func sendRequest(client *HttpClient, path string, method string) (HttpResponse, 
 	req.URL.RawQuery = q.Encode()
 
 	// do :allthethings:
-	response, err := client.HTTPClient.Do(req)
+	response, err := client.Client.Do(req) //nolint:gosec // URL is caller-provided by design
 	if err != nil {
-		return HttpResponse{}, err
+		return HTTPResponse{}, fmt.Errorf("simplehttp: %s %s: %w", method, path, err)
 	}
 	defer response.Body.Close()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return HttpResponse{}, err
+		return HTTPResponse{}, fmt.Errorf("simplehttp: %s %s: reading response body: %w", method, path, err)
 	}
 
-	response_headers := make(map[string][]string)
+	responseHeaders := make(map[string][]string)
 	for k, v := range response.Header {
-		response_headers[k] = v
+		responseHeaders[k] = v
 	}
 
-	resp := HttpResponse{
+	resp := HTTPResponse{
 		Body:    string(body),
 		Code:    response.StatusCode,
-		Headers: response_headers,
+		Headers: responseHeaders,
 	}
 	return resp, nil
 }
 
-func (client *HttpClient) Get(path string) (HttpResponse, error) {
+func (client *HTTPClient) Get(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodGet)
 }
 
-func (client *HttpClient) Post(path string) (HttpResponse, error) {
+func (client *HTTPClient) Post(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodPost)
 }
 
-func (client *HttpClient) Patch(path string) (HttpResponse, error) {
+func (client *HTTPClient) Patch(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodPatch)
 }
 
-func (client *HttpClient) Put(path string) (HttpResponse, error) {
+func (client *HTTPClient) Put(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodPut)
 }
 
-func (client *HttpClient) Delete(path string) (HttpResponse, error) {
+func (client *HTTPClient) Delete(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodDelete)
 }
 
-func (client *HttpClient) Head(path string) (HttpResponse, error) {
+func (client *HTTPClient) Head(path string) (HTTPResponse, error) {
 	return sendRequest(client, path, http.MethodHead)
 }


### PR DESCRIPTION
## Summary

- **Breaking:** Rename `HttpClient` → `HTTPClient` and `HttpResponse` → `HTTPResponse` per Go naming conventions
- **Breaking:** Rename `HTTPClient` struct field to `Client` (was `*http.Client` field named `HTTPClient`, conflicted with new struct name)
- Add `SetTimeout()` method for configurable request timeouts (default remains 10s)
- Wrap all errors from `sendRequest` with method/path context, preserving originals via `%w`
- Guard against nil `Client` field (returns error instead of panic)
- Add tests for error paths, query parameters, and timeout configuration
- Migrate `.golangci.yml` to v2 format; remove deprecated/renamed linters
- Update CI Go matrix from 1.19–1.21 to 1.21–1.23; add Codecov upload
- Document `Head()`, `HTTPResponse` fields, `SetTimeout`, and `context.Context` omission in README
- Add `CLAUDE.md`

## Breaking changes

Consumers will need to update:

| Before | After |
|---|---|
| `simplehttp.HttpClient` | `simplehttp.HTTPClient` |
| `simplehttp.HttpResponse` | `simplehttp.HTTPResponse` |
| `client.HTTPClient` (field) | `client.Client` |

## Test plan

- [x] All existing tests pass (`go test -v ./...` — 15 tests, 0 failures)
- [x] New `TestErrorPaths` covers bad request, 429, auth, redirect loop, and nil client
- [x] New `TestQueryParameters` covers single and multiple query params
- [x] New `TestSetTimeout` verifies default and custom timeout values
- [x] `golangci-lint run` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)